### PR TITLE
dependabot: change pip update schedule from monthly to yearly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,4 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "yearly"


### PR DESCRIPTION
This pull request makes a minor configuration change to the Dependabot settings. The update changes how often Python package dependencies are checked for updates.

* Changed the `interval` for Python (`pip`) dependency updates in `.github/dependabot.yml` from "monthly" to "yearly", reducing the frequency of update checks.